### PR TITLE
Update to Version 1.4 [BREAKING]

### DIFF
--- a/client/client.gen.go
+++ b/client/client.gen.go
@@ -149,6 +149,7 @@ const (
 	GetAllCharactersCharactersGetParamsSortCooking         GetAllCharactersCharactersGetParamsSort = "cooking"
 	GetAllCharactersCharactersGetParamsSortFishing         GetAllCharactersCharactersGetParamsSort = "fishing"
 	GetAllCharactersCharactersGetParamsSortGearcrafting    GetAllCharactersCharactersGetParamsSort = "gearcrafting"
+	GetAllCharactersCharactersGetParamsSortGold            GetAllCharactersCharactersGetParamsSort = "gold"
 	GetAllCharactersCharactersGetParamsSortJewelrycrafting GetAllCharactersCharactersGetParamsSort = "jewelrycrafting"
 	GetAllCharactersCharactersGetParamsSortMining          GetAllCharactersCharactersGetParamsSort = "mining"
 	GetAllCharactersCharactersGetParamsSortWeaponcrafting  GetAllCharactersCharactersGetParamsSort = "weaponcrafting"
@@ -199,6 +200,27 @@ const (
 // ActionItemBankResponseSchema defines model for ActionItemBankResponseSchema.
 type ActionItemBankResponseSchema struct {
 	Data BankItemSchema `json:"data"`
+}
+
+// ActiveEventSchema defines model for ActiveEventSchema.
+type ActiveEventSchema struct {
+	// CreatedAt Start datetime.
+	CreatedAt time.Time `json:"created_at"`
+
+	// Duration Duration in minutes.
+	Duration int `json:"duration"`
+
+	// Expiration Expiration datetime.
+	Expiration time.Time `json:"expiration"`
+
+	// Map Map of the event.
+	Map MapSchema `json:"map"`
+
+	// Name Name of the event.
+	Name string `json:"name"`
+
+	// PreviousSkin Previous map skin.
+	PreviousSkin string `json:"previous_skin"`
 }
 
 // AddAccountSchema defines model for AddAccountSchema.
@@ -422,126 +444,6 @@ type CharacterSchema struct {
 	// InventoryMaxItems Inventory max items.
 	InventoryMaxItems int `json:"inventory_max_items"`
 
-	// InventorySlot1 Deprecated** Inventory slot 1.
-	InventorySlot1 string `json:"inventory_slot1"`
-
-	// InventorySlot10 Deprecated** Inventory slot 10.
-	InventorySlot10 string `json:"inventory_slot10"`
-
-	// InventorySlot10Quantity Deprecated** Inventory 10 quantity.
-	InventorySlot10Quantity int `json:"inventory_slot10_quantity"`
-
-	// InventorySlot11 Deprecated** Inventory slot 11.
-	InventorySlot11 string `json:"inventory_slot11"`
-
-	// InventorySlot11Quantity Deprecated** Inventory 11 quantity.
-	InventorySlot11Quantity int `json:"inventory_slot11_quantity"`
-
-	// InventorySlot12 Deprecated** nventory slot 12.
-	InventorySlot12 string `json:"inventory_slot12"`
-
-	// InventorySlot12Quantity Deprecated** Inventory 12 quantity.
-	InventorySlot12Quantity int `json:"inventory_slot12_quantity"`
-
-	// InventorySlot13 Deprecated** Inventory slot 13.
-	InventorySlot13 string `json:"inventory_slot13"`
-
-	// InventorySlot13Quantity Deprecated** Inventory 13 quantity.
-	InventorySlot13Quantity int `json:"inventory_slot13_quantity"`
-
-	// InventorySlot14 Deprecated** Inventory slot 14.
-	InventorySlot14 string `json:"inventory_slot14"`
-
-	// InventorySlot14Quantity Deprecated** Inventory 14 quantity.
-	InventorySlot14Quantity int `json:"inventory_slot14_quantity"`
-
-	// InventorySlot15 Deprecated** Inventory slot 15.
-	InventorySlot15 string `json:"inventory_slot15"`
-
-	// InventorySlot15Quantity Deprecated** Inventory 15 quantity.
-	InventorySlot15Quantity int `json:"inventory_slot15_quantity"`
-
-	// InventorySlot16 Deprecated** Inventory slot 16.
-	InventorySlot16 string `json:"inventory_slot16"`
-
-	// InventorySlot16Quantity Deprecated** Inventory 16 quantity.
-	InventorySlot16Quantity int `json:"inventory_slot16_quantity"`
-
-	// InventorySlot17 Deprecated** Inventory slot 17.
-	InventorySlot17 string `json:"inventory_slot17"`
-
-	// InventorySlot17Quantity Deprecated** Inventory 17 quantity.
-	InventorySlot17Quantity int `json:"inventory_slot17_quantity"`
-
-	// InventorySlot18 Deprecated** Inventory slot 18.
-	InventorySlot18 string `json:"inventory_slot18"`
-
-	// InventorySlot18Quantity Deprecated** Inventory 18 quantity.
-	InventorySlot18Quantity int `json:"inventory_slot18_quantity"`
-
-	// InventorySlot19 Deprecated** Inventory slot 19.
-	InventorySlot19 string `json:"inventory_slot19"`
-
-	// InventorySlot19Quantity Deprecated** Inventory 19 quantity.
-	InventorySlot19Quantity int `json:"inventory_slot19_quantity"`
-
-	// InventorySlot1Quantity Deprecated** Inventory 1 quantity.
-	InventorySlot1Quantity int `json:"inventory_slot1_quantity"`
-
-	// InventorySlot2 Deprecated** Inventory slot 2.
-	InventorySlot2 string `json:"inventory_slot2"`
-
-	// InventorySlot20 Deprecated** Inventory slot 20.
-	InventorySlot20 string `json:"inventory_slot20"`
-
-	// InventorySlot20Quantity Deprecated** Inventory 20 quantity.
-	InventorySlot20Quantity int `json:"inventory_slot20_quantity"`
-
-	// InventorySlot2Quantity Deprecated** Inventory 2 quantity.
-	InventorySlot2Quantity int `json:"inventory_slot2_quantity"`
-
-	// InventorySlot3 Deprecated** Inventory slot 3.
-	InventorySlot3 string `json:"inventory_slot3"`
-
-	// InventorySlot3Quantity Deprecated** Inventory 3 quantity.
-	InventorySlot3Quantity int `json:"inventory_slot3_quantity"`
-
-	// InventorySlot4 Deprecated** Inventory slot 4.
-	InventorySlot4 string `json:"inventory_slot4"`
-
-	// InventorySlot4Quantity Deprecated** Inventory 4 quantity.
-	InventorySlot4Quantity int `json:"inventory_slot4_quantity"`
-
-	// InventorySlot5 Deprecated** Inventory slot 5.
-	InventorySlot5 string `json:"inventory_slot5"`
-
-	// InventorySlot5Quantity Deprecated** Inventory 5 quantity.
-	InventorySlot5Quantity int `json:"inventory_slot5_quantity"`
-
-	// InventorySlot6 Deprecated** Inventory slot 6.
-	InventorySlot6 string `json:"inventory_slot6"`
-
-	// InventorySlot6Quantity Deprecated** Inventory 6 quantity.
-	InventorySlot6Quantity int `json:"inventory_slot6_quantity"`
-
-	// InventorySlot7 Deprecated** Inventory slot 7.
-	InventorySlot7 string `json:"inventory_slot7"`
-
-	// InventorySlot7Quantity Deprecated** Inventory 7 quantity.
-	InventorySlot7Quantity int `json:"inventory_slot7_quantity"`
-
-	// InventorySlot8 Deprecated** Inventory slot 8.
-	InventorySlot8 string `json:"inventory_slot8"`
-
-	// InventorySlot8Quantity Deprecated** Inventory 8 quantity.
-	InventorySlot8Quantity int `json:"inventory_slot8_quantity"`
-
-	// InventorySlot9 Deprecated** Inventory slot 9.
-	InventorySlot9 string `json:"inventory_slot9"`
-
-	// InventorySlot9Quantity Deprecated** Inventory 9 quantity.
-	InventorySlot9Quantity int `json:"inventory_slot9_quantity"`
-
 	// JewelrycraftingLevel Jewelrycrafting level.
 	JewelrycraftingLevel int `json:"jewelrycrafting_level"`
 
@@ -740,6 +642,59 @@ type CraftingSchema struct {
 	Quantity *int `json:"quantity,omitempty"`
 }
 
+// DataPageActiveEventSchema defines model for DataPage_ActiveEventSchema_.
+type DataPageActiveEventSchema struct {
+	Data  []ActiveEventSchema              `json:"data"`
+	Page  DataPageActiveEventSchema_Page   `json:"page"`
+	Pages *DataPageActiveEventSchema_Pages `json:"pages,omitempty"`
+	Size  DataPageActiveEventSchema_Size   `json:"size"`
+	Total DataPageActiveEventSchema_Total  `json:"total"`
+}
+
+// DataPageActiveEventSchemaPage0 defines model for .
+type DataPageActiveEventSchemaPage0 = int
+
+// DataPageActiveEventSchemaPage1 defines model for .
+type DataPageActiveEventSchemaPage1 = interface{}
+
+// DataPageActiveEventSchema_Page defines model for DataPageActiveEventSchema.Page.
+type DataPageActiveEventSchema_Page struct {
+	union json.RawMessage
+}
+
+// DataPageActiveEventSchemaPages0 defines model for .
+type DataPageActiveEventSchemaPages0 = int
+
+// DataPageActiveEventSchemaPages1 defines model for .
+type DataPageActiveEventSchemaPages1 = interface{}
+
+// DataPageActiveEventSchema_Pages defines model for DataPageActiveEventSchema.Pages.
+type DataPageActiveEventSchema_Pages struct {
+	union json.RawMessage
+}
+
+// DataPageActiveEventSchemaSize0 defines model for .
+type DataPageActiveEventSchemaSize0 = int
+
+// DataPageActiveEventSchemaSize1 defines model for .
+type DataPageActiveEventSchemaSize1 = interface{}
+
+// DataPageActiveEventSchema_Size defines model for DataPageActiveEventSchema.Size.
+type DataPageActiveEventSchema_Size struct {
+	union json.RawMessage
+}
+
+// DataPageActiveEventSchemaTotal0 defines model for .
+type DataPageActiveEventSchemaTotal0 = int
+
+// DataPageActiveEventSchemaTotal1 defines model for .
+type DataPageActiveEventSchemaTotal1 = interface{}
+
+// DataPageActiveEventSchema_Total defines model for DataPageActiveEventSchema.Total.
+type DataPageActiveEventSchema_Total struct {
+	union json.RawMessage
+}
+
 // DataPageCharacterSchema defines model for DataPage_CharacterSchema_.
 type DataPageCharacterSchema struct {
 	Data  []CharacterSchema              `json:"data"`
@@ -790,59 +745,6 @@ type DataPageCharacterSchemaTotal1 = interface{}
 
 // DataPageCharacterSchema_Total defines model for DataPageCharacterSchema.Total.
 type DataPageCharacterSchema_Total struct {
-	union json.RawMessage
-}
-
-// DataPageEventSchema defines model for DataPage_EventSchema_.
-type DataPageEventSchema struct {
-	Data  []EventSchema              `json:"data"`
-	Page  DataPageEventSchema_Page   `json:"page"`
-	Pages *DataPageEventSchema_Pages `json:"pages,omitempty"`
-	Size  DataPageEventSchema_Size   `json:"size"`
-	Total DataPageEventSchema_Total  `json:"total"`
-}
-
-// DataPageEventSchemaPage0 defines model for .
-type DataPageEventSchemaPage0 = int
-
-// DataPageEventSchemaPage1 defines model for .
-type DataPageEventSchemaPage1 = interface{}
-
-// DataPageEventSchema_Page defines model for DataPageEventSchema.Page.
-type DataPageEventSchema_Page struct {
-	union json.RawMessage
-}
-
-// DataPageEventSchemaPages0 defines model for .
-type DataPageEventSchemaPages0 = int
-
-// DataPageEventSchemaPages1 defines model for .
-type DataPageEventSchemaPages1 = interface{}
-
-// DataPageEventSchema_Pages defines model for DataPageEventSchema.Pages.
-type DataPageEventSchema_Pages struct {
-	union json.RawMessage
-}
-
-// DataPageEventSchemaSize0 defines model for .
-type DataPageEventSchemaSize0 = int
-
-// DataPageEventSchemaSize1 defines model for .
-type DataPageEventSchemaSize1 = interface{}
-
-// DataPageEventSchema_Size defines model for DataPageEventSchema.Size.
-type DataPageEventSchema_Size struct {
-	union json.RawMessage
-}
-
-// DataPageEventSchemaTotal0 defines model for .
-type DataPageEventSchemaTotal0 = int
-
-// DataPageEventSchemaTotal1 defines model for .
-type DataPageEventSchemaTotal1 = interface{}
-
-// DataPageEventSchema_Total defines model for DataPageEventSchema.Total.
-type DataPageEventSchema_Total struct {
 	union json.RawMessage
 }
 
@@ -1321,27 +1223,6 @@ type EquipSchemaSlot string
 // EquipmentResponseSchema defines model for EquipmentResponseSchema.
 type EquipmentResponseSchema struct {
 	Data EquipRequestSchema `json:"data"`
-}
-
-// EventSchema defines model for EventSchema.
-type EventSchema struct {
-	// CreatedAt Start datetime.
-	CreatedAt time.Time `json:"created_at"`
-
-	// Duration Duration in minutes.
-	Duration int `json:"duration"`
-
-	// Expiration Expiration datetime.
-	Expiration time.Time `json:"expiration"`
-
-	// Map Map of the event.
-	Map MapSchema `json:"map"`
-
-	// Name Name of the event.
-	Name string `json:"name"`
-
-	// PreviousSkin Previous map skin.
-	PreviousSkin string `json:"previous_skin"`
 }
 
 // FightSchema defines model for FightSchema.
@@ -2303,6 +2184,254 @@ func (t *CraftSchema_Skill) UnmarshalJSON(b []byte) error {
 	return err
 }
 
+// AsDataPageActiveEventSchemaPage0 returns the union data inside the DataPageActiveEventSchema_Page as a DataPageActiveEventSchemaPage0
+func (t DataPageActiveEventSchema_Page) AsDataPageActiveEventSchemaPage0() (DataPageActiveEventSchemaPage0, error) {
+	var body DataPageActiveEventSchemaPage0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDataPageActiveEventSchemaPage0 overwrites any union data inside the DataPageActiveEventSchema_Page as the provided DataPageActiveEventSchemaPage0
+func (t *DataPageActiveEventSchema_Page) FromDataPageActiveEventSchemaPage0(v DataPageActiveEventSchemaPage0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDataPageActiveEventSchemaPage0 performs a merge with any union data inside the DataPageActiveEventSchema_Page, using the provided DataPageActiveEventSchemaPage0
+func (t *DataPageActiveEventSchema_Page) MergeDataPageActiveEventSchemaPage0(v DataPageActiveEventSchemaPage0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsDataPageActiveEventSchemaPage1 returns the union data inside the DataPageActiveEventSchema_Page as a DataPageActiveEventSchemaPage1
+func (t DataPageActiveEventSchema_Page) AsDataPageActiveEventSchemaPage1() (DataPageActiveEventSchemaPage1, error) {
+	var body DataPageActiveEventSchemaPage1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDataPageActiveEventSchemaPage1 overwrites any union data inside the DataPageActiveEventSchema_Page as the provided DataPageActiveEventSchemaPage1
+func (t *DataPageActiveEventSchema_Page) FromDataPageActiveEventSchemaPage1(v DataPageActiveEventSchemaPage1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDataPageActiveEventSchemaPage1 performs a merge with any union data inside the DataPageActiveEventSchema_Page, using the provided DataPageActiveEventSchemaPage1
+func (t *DataPageActiveEventSchema_Page) MergeDataPageActiveEventSchemaPage1(v DataPageActiveEventSchemaPage1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t DataPageActiveEventSchema_Page) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *DataPageActiveEventSchema_Page) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsDataPageActiveEventSchemaPages0 returns the union data inside the DataPageActiveEventSchema_Pages as a DataPageActiveEventSchemaPages0
+func (t DataPageActiveEventSchema_Pages) AsDataPageActiveEventSchemaPages0() (DataPageActiveEventSchemaPages0, error) {
+	var body DataPageActiveEventSchemaPages0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDataPageActiveEventSchemaPages0 overwrites any union data inside the DataPageActiveEventSchema_Pages as the provided DataPageActiveEventSchemaPages0
+func (t *DataPageActiveEventSchema_Pages) FromDataPageActiveEventSchemaPages0(v DataPageActiveEventSchemaPages0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDataPageActiveEventSchemaPages0 performs a merge with any union data inside the DataPageActiveEventSchema_Pages, using the provided DataPageActiveEventSchemaPages0
+func (t *DataPageActiveEventSchema_Pages) MergeDataPageActiveEventSchemaPages0(v DataPageActiveEventSchemaPages0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsDataPageActiveEventSchemaPages1 returns the union data inside the DataPageActiveEventSchema_Pages as a DataPageActiveEventSchemaPages1
+func (t DataPageActiveEventSchema_Pages) AsDataPageActiveEventSchemaPages1() (DataPageActiveEventSchemaPages1, error) {
+	var body DataPageActiveEventSchemaPages1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDataPageActiveEventSchemaPages1 overwrites any union data inside the DataPageActiveEventSchema_Pages as the provided DataPageActiveEventSchemaPages1
+func (t *DataPageActiveEventSchema_Pages) FromDataPageActiveEventSchemaPages1(v DataPageActiveEventSchemaPages1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDataPageActiveEventSchemaPages1 performs a merge with any union data inside the DataPageActiveEventSchema_Pages, using the provided DataPageActiveEventSchemaPages1
+func (t *DataPageActiveEventSchema_Pages) MergeDataPageActiveEventSchemaPages1(v DataPageActiveEventSchemaPages1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t DataPageActiveEventSchema_Pages) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *DataPageActiveEventSchema_Pages) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsDataPageActiveEventSchemaSize0 returns the union data inside the DataPageActiveEventSchema_Size as a DataPageActiveEventSchemaSize0
+func (t DataPageActiveEventSchema_Size) AsDataPageActiveEventSchemaSize0() (DataPageActiveEventSchemaSize0, error) {
+	var body DataPageActiveEventSchemaSize0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDataPageActiveEventSchemaSize0 overwrites any union data inside the DataPageActiveEventSchema_Size as the provided DataPageActiveEventSchemaSize0
+func (t *DataPageActiveEventSchema_Size) FromDataPageActiveEventSchemaSize0(v DataPageActiveEventSchemaSize0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDataPageActiveEventSchemaSize0 performs a merge with any union data inside the DataPageActiveEventSchema_Size, using the provided DataPageActiveEventSchemaSize0
+func (t *DataPageActiveEventSchema_Size) MergeDataPageActiveEventSchemaSize0(v DataPageActiveEventSchemaSize0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsDataPageActiveEventSchemaSize1 returns the union data inside the DataPageActiveEventSchema_Size as a DataPageActiveEventSchemaSize1
+func (t DataPageActiveEventSchema_Size) AsDataPageActiveEventSchemaSize1() (DataPageActiveEventSchemaSize1, error) {
+	var body DataPageActiveEventSchemaSize1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDataPageActiveEventSchemaSize1 overwrites any union data inside the DataPageActiveEventSchema_Size as the provided DataPageActiveEventSchemaSize1
+func (t *DataPageActiveEventSchema_Size) FromDataPageActiveEventSchemaSize1(v DataPageActiveEventSchemaSize1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDataPageActiveEventSchemaSize1 performs a merge with any union data inside the DataPageActiveEventSchema_Size, using the provided DataPageActiveEventSchemaSize1
+func (t *DataPageActiveEventSchema_Size) MergeDataPageActiveEventSchemaSize1(v DataPageActiveEventSchemaSize1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t DataPageActiveEventSchema_Size) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *DataPageActiveEventSchema_Size) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsDataPageActiveEventSchemaTotal0 returns the union data inside the DataPageActiveEventSchema_Total as a DataPageActiveEventSchemaTotal0
+func (t DataPageActiveEventSchema_Total) AsDataPageActiveEventSchemaTotal0() (DataPageActiveEventSchemaTotal0, error) {
+	var body DataPageActiveEventSchemaTotal0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDataPageActiveEventSchemaTotal0 overwrites any union data inside the DataPageActiveEventSchema_Total as the provided DataPageActiveEventSchemaTotal0
+func (t *DataPageActiveEventSchema_Total) FromDataPageActiveEventSchemaTotal0(v DataPageActiveEventSchemaTotal0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDataPageActiveEventSchemaTotal0 performs a merge with any union data inside the DataPageActiveEventSchema_Total, using the provided DataPageActiveEventSchemaTotal0
+func (t *DataPageActiveEventSchema_Total) MergeDataPageActiveEventSchemaTotal0(v DataPageActiveEventSchemaTotal0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsDataPageActiveEventSchemaTotal1 returns the union data inside the DataPageActiveEventSchema_Total as a DataPageActiveEventSchemaTotal1
+func (t DataPageActiveEventSchema_Total) AsDataPageActiveEventSchemaTotal1() (DataPageActiveEventSchemaTotal1, error) {
+	var body DataPageActiveEventSchemaTotal1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDataPageActiveEventSchemaTotal1 overwrites any union data inside the DataPageActiveEventSchema_Total as the provided DataPageActiveEventSchemaTotal1
+func (t *DataPageActiveEventSchema_Total) FromDataPageActiveEventSchemaTotal1(v DataPageActiveEventSchemaTotal1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDataPageActiveEventSchemaTotal1 performs a merge with any union data inside the DataPageActiveEventSchema_Total, using the provided DataPageActiveEventSchemaTotal1
+func (t *DataPageActiveEventSchema_Total) MergeDataPageActiveEventSchemaTotal1(v DataPageActiveEventSchemaTotal1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t DataPageActiveEventSchema_Total) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *DataPageActiveEventSchema_Total) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
 // AsDataPageCharacterSchemaPage0 returns the union data inside the DataPageCharacterSchema_Page as a DataPageCharacterSchemaPage0
 func (t DataPageCharacterSchema_Page) AsDataPageCharacterSchemaPage0() (DataPageCharacterSchemaPage0, error) {
 	var body DataPageCharacterSchemaPage0
@@ -2547,254 +2676,6 @@ func (t DataPageCharacterSchema_Total) MarshalJSON() ([]byte, error) {
 }
 
 func (t *DataPageCharacterSchema_Total) UnmarshalJSON(b []byte) error {
-	err := t.union.UnmarshalJSON(b)
-	return err
-}
-
-// AsDataPageEventSchemaPage0 returns the union data inside the DataPageEventSchema_Page as a DataPageEventSchemaPage0
-func (t DataPageEventSchema_Page) AsDataPageEventSchemaPage0() (DataPageEventSchemaPage0, error) {
-	var body DataPageEventSchemaPage0
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromDataPageEventSchemaPage0 overwrites any union data inside the DataPageEventSchema_Page as the provided DataPageEventSchemaPage0
-func (t *DataPageEventSchema_Page) FromDataPageEventSchemaPage0(v DataPageEventSchemaPage0) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeDataPageEventSchemaPage0 performs a merge with any union data inside the DataPageEventSchema_Page, using the provided DataPageEventSchemaPage0
-func (t *DataPageEventSchema_Page) MergeDataPageEventSchemaPage0(v DataPageEventSchemaPage0) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-// AsDataPageEventSchemaPage1 returns the union data inside the DataPageEventSchema_Page as a DataPageEventSchemaPage1
-func (t DataPageEventSchema_Page) AsDataPageEventSchemaPage1() (DataPageEventSchemaPage1, error) {
-	var body DataPageEventSchemaPage1
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromDataPageEventSchemaPage1 overwrites any union data inside the DataPageEventSchema_Page as the provided DataPageEventSchemaPage1
-func (t *DataPageEventSchema_Page) FromDataPageEventSchemaPage1(v DataPageEventSchemaPage1) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeDataPageEventSchemaPage1 performs a merge with any union data inside the DataPageEventSchema_Page, using the provided DataPageEventSchemaPage1
-func (t *DataPageEventSchema_Page) MergeDataPageEventSchemaPage1(v DataPageEventSchemaPage1) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-func (t DataPageEventSchema_Page) MarshalJSON() ([]byte, error) {
-	b, err := t.union.MarshalJSON()
-	return b, err
-}
-
-func (t *DataPageEventSchema_Page) UnmarshalJSON(b []byte) error {
-	err := t.union.UnmarshalJSON(b)
-	return err
-}
-
-// AsDataPageEventSchemaPages0 returns the union data inside the DataPageEventSchema_Pages as a DataPageEventSchemaPages0
-func (t DataPageEventSchema_Pages) AsDataPageEventSchemaPages0() (DataPageEventSchemaPages0, error) {
-	var body DataPageEventSchemaPages0
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromDataPageEventSchemaPages0 overwrites any union data inside the DataPageEventSchema_Pages as the provided DataPageEventSchemaPages0
-func (t *DataPageEventSchema_Pages) FromDataPageEventSchemaPages0(v DataPageEventSchemaPages0) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeDataPageEventSchemaPages0 performs a merge with any union data inside the DataPageEventSchema_Pages, using the provided DataPageEventSchemaPages0
-func (t *DataPageEventSchema_Pages) MergeDataPageEventSchemaPages0(v DataPageEventSchemaPages0) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-// AsDataPageEventSchemaPages1 returns the union data inside the DataPageEventSchema_Pages as a DataPageEventSchemaPages1
-func (t DataPageEventSchema_Pages) AsDataPageEventSchemaPages1() (DataPageEventSchemaPages1, error) {
-	var body DataPageEventSchemaPages1
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromDataPageEventSchemaPages1 overwrites any union data inside the DataPageEventSchema_Pages as the provided DataPageEventSchemaPages1
-func (t *DataPageEventSchema_Pages) FromDataPageEventSchemaPages1(v DataPageEventSchemaPages1) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeDataPageEventSchemaPages1 performs a merge with any union data inside the DataPageEventSchema_Pages, using the provided DataPageEventSchemaPages1
-func (t *DataPageEventSchema_Pages) MergeDataPageEventSchemaPages1(v DataPageEventSchemaPages1) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-func (t DataPageEventSchema_Pages) MarshalJSON() ([]byte, error) {
-	b, err := t.union.MarshalJSON()
-	return b, err
-}
-
-func (t *DataPageEventSchema_Pages) UnmarshalJSON(b []byte) error {
-	err := t.union.UnmarshalJSON(b)
-	return err
-}
-
-// AsDataPageEventSchemaSize0 returns the union data inside the DataPageEventSchema_Size as a DataPageEventSchemaSize0
-func (t DataPageEventSchema_Size) AsDataPageEventSchemaSize0() (DataPageEventSchemaSize0, error) {
-	var body DataPageEventSchemaSize0
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromDataPageEventSchemaSize0 overwrites any union data inside the DataPageEventSchema_Size as the provided DataPageEventSchemaSize0
-func (t *DataPageEventSchema_Size) FromDataPageEventSchemaSize0(v DataPageEventSchemaSize0) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeDataPageEventSchemaSize0 performs a merge with any union data inside the DataPageEventSchema_Size, using the provided DataPageEventSchemaSize0
-func (t *DataPageEventSchema_Size) MergeDataPageEventSchemaSize0(v DataPageEventSchemaSize0) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-// AsDataPageEventSchemaSize1 returns the union data inside the DataPageEventSchema_Size as a DataPageEventSchemaSize1
-func (t DataPageEventSchema_Size) AsDataPageEventSchemaSize1() (DataPageEventSchemaSize1, error) {
-	var body DataPageEventSchemaSize1
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromDataPageEventSchemaSize1 overwrites any union data inside the DataPageEventSchema_Size as the provided DataPageEventSchemaSize1
-func (t *DataPageEventSchema_Size) FromDataPageEventSchemaSize1(v DataPageEventSchemaSize1) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeDataPageEventSchemaSize1 performs a merge with any union data inside the DataPageEventSchema_Size, using the provided DataPageEventSchemaSize1
-func (t *DataPageEventSchema_Size) MergeDataPageEventSchemaSize1(v DataPageEventSchemaSize1) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-func (t DataPageEventSchema_Size) MarshalJSON() ([]byte, error) {
-	b, err := t.union.MarshalJSON()
-	return b, err
-}
-
-func (t *DataPageEventSchema_Size) UnmarshalJSON(b []byte) error {
-	err := t.union.UnmarshalJSON(b)
-	return err
-}
-
-// AsDataPageEventSchemaTotal0 returns the union data inside the DataPageEventSchema_Total as a DataPageEventSchemaTotal0
-func (t DataPageEventSchema_Total) AsDataPageEventSchemaTotal0() (DataPageEventSchemaTotal0, error) {
-	var body DataPageEventSchemaTotal0
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromDataPageEventSchemaTotal0 overwrites any union data inside the DataPageEventSchema_Total as the provided DataPageEventSchemaTotal0
-func (t *DataPageEventSchema_Total) FromDataPageEventSchemaTotal0(v DataPageEventSchemaTotal0) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeDataPageEventSchemaTotal0 performs a merge with any union data inside the DataPageEventSchema_Total, using the provided DataPageEventSchemaTotal0
-func (t *DataPageEventSchema_Total) MergeDataPageEventSchemaTotal0(v DataPageEventSchemaTotal0) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-// AsDataPageEventSchemaTotal1 returns the union data inside the DataPageEventSchema_Total as a DataPageEventSchemaTotal1
-func (t DataPageEventSchema_Total) AsDataPageEventSchemaTotal1() (DataPageEventSchemaTotal1, error) {
-	var body DataPageEventSchemaTotal1
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromDataPageEventSchemaTotal1 overwrites any union data inside the DataPageEventSchema_Total as the provided DataPageEventSchemaTotal1
-func (t *DataPageEventSchema_Total) FromDataPageEventSchemaTotal1(v DataPageEventSchemaTotal1) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeDataPageEventSchemaTotal1 performs a merge with any union data inside the DataPageEventSchema_Total, using the provided DataPageEventSchemaTotal1
-func (t *DataPageEventSchema_Total) MergeDataPageEventSchemaTotal1(v DataPageEventSchemaTotal1) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-func (t DataPageEventSchema_Total) MarshalJSON() ([]byte, error) {
-	b, err := t.union.MarshalJSON()
-	return b, err
-}
-
-func (t *DataPageEventSchema_Total) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
@@ -7924,7 +7805,7 @@ func (r GetCharacterCharactersNameGetResponse) StatusCode() int {
 type GetAllEventsEventsGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *DataPageEventSchema
+	JSON200      *DataPageActiveEventSchema
 }
 
 // Status returns HTTPResponse.Status
@@ -9285,7 +9166,7 @@ func ParseGetAllEventsEventsGetResponse(rsp *http.Response) (*GetAllEventsEvents
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest DataPageEventSchema
+		var dest DataPageActiveEventSchema
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/spec/openapi-3.0.json
+++ b/spec/openapi-3.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Artifacts API",
     "description": "\nArtifacts is an API-based MMO game where you can manage 5 characters to explore, fight, gather resources, craft items and much more.\n\nWebsite: https://artifactsmmo.com/\n\nDocumentation: https://docs.artifactsmmo.com/\n\nOpenAPI Spec: https://api.artifactsmmo.com/openapi.json\n",
-    "version": "1.3"
+    "version": "1.4"
   },
   "paths": {
     "/my/{name}/action/move": {
@@ -1441,7 +1441,8 @@
                 "weaponcrafting",
                 "gearcrafting",
                 "jewelrycrafting",
-                "cooking"
+                "cooking",
+                "gold"
               ],
               "type": "string",
               "title": "Sort",
@@ -2171,7 +2172,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DataPage_EventSchema_"
+                  "$ref": "#/components/schemas/DataPage_ActiveEventSchema_"
                 }
               }
             }
@@ -2376,6 +2377,55 @@
           "data"
         ],
         "title": "ActionItemBankResponseSchema"
+      },
+      "ActiveEventSchema": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Name of the event."
+          },
+          "map": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MapSchema"
+              }
+            ],
+            "description": "Map of the event."
+          },
+          "previous_skin": {
+            "type": "string",
+            "title": "Previous Skin",
+            "description": "Previous map skin."
+          },
+          "duration": {
+            "type": "integer",
+            "title": "Duration",
+            "description": "Duration in minutes."
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expiration",
+            "description": "Expiration datetime."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Start datetime."
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "map",
+          "previous_skin",
+          "duration",
+          "expiration",
+          "created_at"
+        ],
+        "title": "ActiveEventSchema"
       },
       "AddAccountSchema": {
         "properties": {
@@ -3041,206 +3091,6 @@
             "type": "array",
             "title": "Inventory",
             "description": "List of inventory slots."
-          },
-          "inventory_slot1": {
-            "type": "string",
-            "title": "Inventory Slot1",
-            "description": "Deprecated** Inventory slot 1."
-          },
-          "inventory_slot1_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot1 Quantity",
-            "description": "Deprecated** Inventory 1 quantity."
-          },
-          "inventory_slot2": {
-            "type": "string",
-            "title": "Inventory Slot2",
-            "description": "Deprecated** Inventory slot 2."
-          },
-          "inventory_slot2_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot2 Quantity",
-            "description": "Deprecated** Inventory 2 quantity."
-          },
-          "inventory_slot3": {
-            "type": "string",
-            "title": "Inventory Slot3",
-            "description": "Deprecated** Inventory slot 3."
-          },
-          "inventory_slot3_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot3 Quantity",
-            "description": "Deprecated** Inventory 3 quantity."
-          },
-          "inventory_slot4": {
-            "type": "string",
-            "title": "Inventory Slot4",
-            "description": "Deprecated** Inventory slot 4."
-          },
-          "inventory_slot4_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot4 Quantity",
-            "description": "Deprecated** Inventory 4 quantity."
-          },
-          "inventory_slot5": {
-            "type": "string",
-            "title": "Inventory Slot5",
-            "description": "Deprecated** Inventory slot 5."
-          },
-          "inventory_slot5_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot5 Quantity",
-            "description": "Deprecated** Inventory 5 quantity."
-          },
-          "inventory_slot6": {
-            "type": "string",
-            "title": "Inventory Slot6",
-            "description": "Deprecated** Inventory slot 6."
-          },
-          "inventory_slot6_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot6 Quantity",
-            "description": "Deprecated** Inventory 6 quantity."
-          },
-          "inventory_slot7": {
-            "type": "string",
-            "title": "Inventory Slot7",
-            "description": "Deprecated** Inventory slot 7."
-          },
-          "inventory_slot7_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot7 Quantity",
-            "description": "Deprecated** Inventory 7 quantity."
-          },
-          "inventory_slot8": {
-            "type": "string",
-            "title": "Inventory Slot8",
-            "description": "Deprecated** Inventory slot 8."
-          },
-          "inventory_slot8_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot8 Quantity",
-            "description": "Deprecated** Inventory 8 quantity."
-          },
-          "inventory_slot9": {
-            "type": "string",
-            "title": "Inventory Slot9",
-            "description": "Deprecated** Inventory slot 9."
-          },
-          "inventory_slot9_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot9 Quantity",
-            "description": "Deprecated** Inventory 9 quantity."
-          },
-          "inventory_slot10": {
-            "type": "string",
-            "title": "Inventory Slot10",
-            "description": "Deprecated** Inventory slot 10."
-          },
-          "inventory_slot10_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot10 Quantity",
-            "description": "Deprecated** Inventory 10 quantity."
-          },
-          "inventory_slot11": {
-            "type": "string",
-            "title": "Inventory Slot11",
-            "description": "Deprecated** Inventory slot 11."
-          },
-          "inventory_slot11_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot11 Quantity",
-            "description": "Deprecated** Inventory 11 quantity."
-          },
-          "inventory_slot12": {
-            "type": "string",
-            "title": "Inventory Slot12",
-            "description": "Deprecated** nventory slot 12."
-          },
-          "inventory_slot12_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot12 Quantity",
-            "description": "Deprecated** Inventory 12 quantity."
-          },
-          "inventory_slot13": {
-            "type": "string",
-            "title": "Inventory Slot13",
-            "description": "Deprecated** Inventory slot 13."
-          },
-          "inventory_slot13_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot13 Quantity",
-            "description": "Deprecated** Inventory 13 quantity."
-          },
-          "inventory_slot14": {
-            "type": "string",
-            "title": "Inventory Slot14",
-            "description": "Deprecated** Inventory slot 14."
-          },
-          "inventory_slot14_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot14 Quantity",
-            "description": "Deprecated** Inventory 14 quantity."
-          },
-          "inventory_slot15": {
-            "type": "string",
-            "title": "Inventory Slot15",
-            "description": "Deprecated** Inventory slot 15."
-          },
-          "inventory_slot15_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot15 Quantity",
-            "description": "Deprecated** Inventory 15 quantity."
-          },
-          "inventory_slot16": {
-            "type": "string",
-            "title": "Inventory Slot16",
-            "description": "Deprecated** Inventory slot 16."
-          },
-          "inventory_slot16_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot16 Quantity",
-            "description": "Deprecated** Inventory 16 quantity."
-          },
-          "inventory_slot17": {
-            "type": "string",
-            "title": "Inventory Slot17",
-            "description": "Deprecated** Inventory slot 17."
-          },
-          "inventory_slot17_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot17 Quantity",
-            "description": "Deprecated** Inventory 17 quantity."
-          },
-          "inventory_slot18": {
-            "type": "string",
-            "title": "Inventory Slot18",
-            "description": "Deprecated** Inventory slot 18."
-          },
-          "inventory_slot18_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot18 Quantity",
-            "description": "Deprecated** Inventory 18 quantity."
-          },
-          "inventory_slot19": {
-            "type": "string",
-            "title": "Inventory Slot19",
-            "description": "Deprecated** Inventory slot 19."
-          },
-          "inventory_slot19_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot19 Quantity",
-            "description": "Deprecated** Inventory 19 quantity."
-          },
-          "inventory_slot20": {
-            "type": "string",
-            "title": "Inventory Slot20",
-            "description": "Deprecated** Inventory slot 20."
-          },
-          "inventory_slot20_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot20 Quantity",
-            "description": "Deprecated** Inventory 20 quantity."
           }
         },
         "type": "object",
@@ -3313,47 +3163,7 @@
           "task_type",
           "task_progress",
           "task_total",
-          "inventory_max_items",
-          "inventory_slot1",
-          "inventory_slot1_quantity",
-          "inventory_slot2",
-          "inventory_slot2_quantity",
-          "inventory_slot3",
-          "inventory_slot3_quantity",
-          "inventory_slot4",
-          "inventory_slot4_quantity",
-          "inventory_slot5",
-          "inventory_slot5_quantity",
-          "inventory_slot6",
-          "inventory_slot6_quantity",
-          "inventory_slot7",
-          "inventory_slot7_quantity",
-          "inventory_slot8",
-          "inventory_slot8_quantity",
-          "inventory_slot9",
-          "inventory_slot9_quantity",
-          "inventory_slot10",
-          "inventory_slot10_quantity",
-          "inventory_slot11",
-          "inventory_slot11_quantity",
-          "inventory_slot12",
-          "inventory_slot12_quantity",
-          "inventory_slot13",
-          "inventory_slot13_quantity",
-          "inventory_slot14",
-          "inventory_slot14_quantity",
-          "inventory_slot15",
-          "inventory_slot15_quantity",
-          "inventory_slot16",
-          "inventory_slot16_quantity",
-          "inventory_slot17",
-          "inventory_slot17_quantity",
-          "inventory_slot18",
-          "inventory_slot18_quantity",
-          "inventory_slot19",
-          "inventory_slot19_quantity",
-          "inventory_slot20",
-          "inventory_slot20_quantity"
+          "inventory_max_items"
         ],
         "title": "CharacterSchema"
       },
@@ -3406,8 +3216,6 @@
         "required": [
           "total_seconds",
           "remaining_seconds",
-          "totalSeconds",
-          "remainingSeconds",
           "started_at",
           "expiration",
           "reason"
@@ -3494,6 +3302,73 @@
         ],
         "title": "CraftingSchema"
       },
+      "DataPage_ActiveEventSchema_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ActiveEventSchema"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "total": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "nullable": true
+              }
+            ],
+            "title": "Total"
+          },
+          "page": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1
+              },
+              {
+                "nullable": true
+              }
+            ],
+            "title": "Page"
+          },
+          "size": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1
+              },
+              {
+                "nullable": true
+              }
+            ],
+            "title": "Size"
+          },
+          "pages": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "nullable": true
+              }
+            ],
+            "title": "Pages"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "total",
+          "page",
+          "size"
+        ],
+        "title": "DataPage[ActiveEventSchema]"
+      },
       "DataPage_CharacterSchema_": {
         "properties": {
           "data": {
@@ -3560,73 +3435,6 @@
           "size"
         ],
         "title": "DataPage[CharacterSchema]"
-      },
-      "DataPage_EventSchema_": {
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/EventSchema"
-            },
-            "type": "array",
-            "title": "Data"
-          },
-          "total": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 0
-              },
-              {
-                "nullable": true
-              }
-            ],
-            "title": "Total"
-          },
-          "page": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 1
-              },
-              {
-                "nullable": true
-              }
-            ],
-            "title": "Page"
-          },
-          "size": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 1
-              },
-              {
-                "nullable": true
-              }
-            ],
-            "title": "Size"
-          },
-          "pages": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 0
-              },
-              {
-                "nullable": true
-              }
-            ],
-            "title": "Pages"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data",
-          "total",
-          "page",
-          "size"
-        ],
-        "title": "DataPage[EventSchema]"
       },
       "DataPage_GEItemSchema_": {
         "properties": {
@@ -4371,55 +4179,6 @@
           "data"
         ],
         "title": "EquipmentResponseSchema"
-      },
-      "EventSchema": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name",
-            "description": "Name of the event."
-          },
-          "map": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MapSchema"
-              }
-            ],
-            "description": "Map of the event."
-          },
-          "previous_skin": {
-            "type": "string",
-            "title": "Previous Skin",
-            "description": "Previous map skin."
-          },
-          "duration": {
-            "type": "integer",
-            "title": "Duration",
-            "description": "Duration in minutes."
-          },
-          "expiration": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Expiration",
-            "description": "Expiration datetime."
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At",
-            "description": "Start datetime."
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "map",
-          "previous_skin",
-          "duration",
-          "expiration",
-          "created_at"
-        ],
-        "title": "EventSchema"
       },
       "FightSchema": {
         "properties": {

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Artifacts API",
     "description": "\nArtifacts is an API-based MMO game where you can manage 5 characters to explore, fight, gather resources, craft items and much more.\n\nWebsite: https://artifactsmmo.com/\n\nDocumentation: https://docs.artifactsmmo.com/\n\nOpenAPI Spec: https://api.artifactsmmo.com/openapi.json\n",
-    "version": "1.3"
+    "version": "1.4"
   },
   "paths": {
     "/my/{name}/action/move": {
@@ -1441,7 +1441,8 @@
                 "weaponcrafting",
                 "gearcrafting",
                 "jewelrycrafting",
-                "cooking"
+                "cooking",
+                "gold"
               ],
               "type": "string",
               "title": "Sort",
@@ -2171,7 +2172,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DataPage_EventSchema_"
+                  "$ref": "#/components/schemas/DataPage_ActiveEventSchema_"
                 }
               }
             }
@@ -2376,6 +2377,55 @@
           "data"
         ],
         "title": "ActionItemBankResponseSchema"
+      },
+      "ActiveEventSchema": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Name of the event."
+          },
+          "map": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MapSchema"
+              }
+            ],
+            "description": "Map of the event."
+          },
+          "previous_skin": {
+            "type": "string",
+            "title": "Previous Skin",
+            "description": "Previous map skin."
+          },
+          "duration": {
+            "type": "integer",
+            "title": "Duration",
+            "description": "Duration in minutes."
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Expiration",
+            "description": "Expiration datetime."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Start datetime."
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "map",
+          "previous_skin",
+          "duration",
+          "expiration",
+          "created_at"
+        ],
+        "title": "ActiveEventSchema"
       },
       "AddAccountSchema": {
         "properties": {
@@ -3041,206 +3091,6 @@
             "type": "array",
             "title": "Inventory",
             "description": "List of inventory slots."
-          },
-          "inventory_slot1": {
-            "type": "string",
-            "title": "Inventory Slot1",
-            "description": "Deprecated** Inventory slot 1."
-          },
-          "inventory_slot1_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot1 Quantity",
-            "description": "Deprecated** Inventory 1 quantity."
-          },
-          "inventory_slot2": {
-            "type": "string",
-            "title": "Inventory Slot2",
-            "description": "Deprecated** Inventory slot 2."
-          },
-          "inventory_slot2_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot2 Quantity",
-            "description": "Deprecated** Inventory 2 quantity."
-          },
-          "inventory_slot3": {
-            "type": "string",
-            "title": "Inventory Slot3",
-            "description": "Deprecated** Inventory slot 3."
-          },
-          "inventory_slot3_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot3 Quantity",
-            "description": "Deprecated** Inventory 3 quantity."
-          },
-          "inventory_slot4": {
-            "type": "string",
-            "title": "Inventory Slot4",
-            "description": "Deprecated** Inventory slot 4."
-          },
-          "inventory_slot4_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot4 Quantity",
-            "description": "Deprecated** Inventory 4 quantity."
-          },
-          "inventory_slot5": {
-            "type": "string",
-            "title": "Inventory Slot5",
-            "description": "Deprecated** Inventory slot 5."
-          },
-          "inventory_slot5_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot5 Quantity",
-            "description": "Deprecated** Inventory 5 quantity."
-          },
-          "inventory_slot6": {
-            "type": "string",
-            "title": "Inventory Slot6",
-            "description": "Deprecated** Inventory slot 6."
-          },
-          "inventory_slot6_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot6 Quantity",
-            "description": "Deprecated** Inventory 6 quantity."
-          },
-          "inventory_slot7": {
-            "type": "string",
-            "title": "Inventory Slot7",
-            "description": "Deprecated** Inventory slot 7."
-          },
-          "inventory_slot7_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot7 Quantity",
-            "description": "Deprecated** Inventory 7 quantity."
-          },
-          "inventory_slot8": {
-            "type": "string",
-            "title": "Inventory Slot8",
-            "description": "Deprecated** Inventory slot 8."
-          },
-          "inventory_slot8_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot8 Quantity",
-            "description": "Deprecated** Inventory 8 quantity."
-          },
-          "inventory_slot9": {
-            "type": "string",
-            "title": "Inventory Slot9",
-            "description": "Deprecated** Inventory slot 9."
-          },
-          "inventory_slot9_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot9 Quantity",
-            "description": "Deprecated** Inventory 9 quantity."
-          },
-          "inventory_slot10": {
-            "type": "string",
-            "title": "Inventory Slot10",
-            "description": "Deprecated** Inventory slot 10."
-          },
-          "inventory_slot10_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot10 Quantity",
-            "description": "Deprecated** Inventory 10 quantity."
-          },
-          "inventory_slot11": {
-            "type": "string",
-            "title": "Inventory Slot11",
-            "description": "Deprecated** Inventory slot 11."
-          },
-          "inventory_slot11_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot11 Quantity",
-            "description": "Deprecated** Inventory 11 quantity."
-          },
-          "inventory_slot12": {
-            "type": "string",
-            "title": "Inventory Slot12",
-            "description": "Deprecated** nventory slot 12."
-          },
-          "inventory_slot12_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot12 Quantity",
-            "description": "Deprecated** Inventory 12 quantity."
-          },
-          "inventory_slot13": {
-            "type": "string",
-            "title": "Inventory Slot13",
-            "description": "Deprecated** Inventory slot 13."
-          },
-          "inventory_slot13_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot13 Quantity",
-            "description": "Deprecated** Inventory 13 quantity."
-          },
-          "inventory_slot14": {
-            "type": "string",
-            "title": "Inventory Slot14",
-            "description": "Deprecated** Inventory slot 14."
-          },
-          "inventory_slot14_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot14 Quantity",
-            "description": "Deprecated** Inventory 14 quantity."
-          },
-          "inventory_slot15": {
-            "type": "string",
-            "title": "Inventory Slot15",
-            "description": "Deprecated** Inventory slot 15."
-          },
-          "inventory_slot15_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot15 Quantity",
-            "description": "Deprecated** Inventory 15 quantity."
-          },
-          "inventory_slot16": {
-            "type": "string",
-            "title": "Inventory Slot16",
-            "description": "Deprecated** Inventory slot 16."
-          },
-          "inventory_slot16_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot16 Quantity",
-            "description": "Deprecated** Inventory 16 quantity."
-          },
-          "inventory_slot17": {
-            "type": "string",
-            "title": "Inventory Slot17",
-            "description": "Deprecated** Inventory slot 17."
-          },
-          "inventory_slot17_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot17 Quantity",
-            "description": "Deprecated** Inventory 17 quantity."
-          },
-          "inventory_slot18": {
-            "type": "string",
-            "title": "Inventory Slot18",
-            "description": "Deprecated** Inventory slot 18."
-          },
-          "inventory_slot18_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot18 Quantity",
-            "description": "Deprecated** Inventory 18 quantity."
-          },
-          "inventory_slot19": {
-            "type": "string",
-            "title": "Inventory Slot19",
-            "description": "Deprecated** Inventory slot 19."
-          },
-          "inventory_slot19_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot19 Quantity",
-            "description": "Deprecated** Inventory 19 quantity."
-          },
-          "inventory_slot20": {
-            "type": "string",
-            "title": "Inventory Slot20",
-            "description": "Deprecated** Inventory slot 20."
-          },
-          "inventory_slot20_quantity": {
-            "type": "integer",
-            "title": "Inventory Slot20 Quantity",
-            "description": "Deprecated** Inventory 20 quantity."
           }
         },
         "type": "object",
@@ -3313,47 +3163,7 @@
           "task_type",
           "task_progress",
           "task_total",
-          "inventory_max_items",
-          "inventory_slot1",
-          "inventory_slot1_quantity",
-          "inventory_slot2",
-          "inventory_slot2_quantity",
-          "inventory_slot3",
-          "inventory_slot3_quantity",
-          "inventory_slot4",
-          "inventory_slot4_quantity",
-          "inventory_slot5",
-          "inventory_slot5_quantity",
-          "inventory_slot6",
-          "inventory_slot6_quantity",
-          "inventory_slot7",
-          "inventory_slot7_quantity",
-          "inventory_slot8",
-          "inventory_slot8_quantity",
-          "inventory_slot9",
-          "inventory_slot9_quantity",
-          "inventory_slot10",
-          "inventory_slot10_quantity",
-          "inventory_slot11",
-          "inventory_slot11_quantity",
-          "inventory_slot12",
-          "inventory_slot12_quantity",
-          "inventory_slot13",
-          "inventory_slot13_quantity",
-          "inventory_slot14",
-          "inventory_slot14_quantity",
-          "inventory_slot15",
-          "inventory_slot15_quantity",
-          "inventory_slot16",
-          "inventory_slot16_quantity",
-          "inventory_slot17",
-          "inventory_slot17_quantity",
-          "inventory_slot18",
-          "inventory_slot18_quantity",
-          "inventory_slot19",
-          "inventory_slot19_quantity",
-          "inventory_slot20",
-          "inventory_slot20_quantity"
+          "inventory_max_items"
         ],
         "title": "CharacterSchema"
       },
@@ -3368,16 +3178,6 @@
             "type": "integer",
             "title": "Remaining Seconds",
             "description": "The remaining seconds of the cooldown."
-          },
-          "totalSeconds": {
-            "type": "integer",
-            "title": "Totalseconds",
-            "description": "Deprecated** The total seconds of the cooldown."
-          },
-          "remainingSeconds": {
-            "type": "integer",
-            "title": "Remainingseconds",
-            "description": "Deprecated** The remaining seconds of the cooldown."
           },
           "started_at": {
             "type": "string",
@@ -3416,8 +3216,6 @@
         "required": [
           "total_seconds",
           "remaining_seconds",
-          "totalSeconds",
-          "remainingSeconds",
           "started_at",
           "expiration",
           "reason"
@@ -3504,6 +3302,73 @@
         ],
         "title": "CraftingSchema"
       },
+      "DataPage_ActiveEventSchema_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ActiveEventSchema"
+            },
+            "type": "array",
+            "title": "Data"
+          },
+          "total": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total"
+          },
+          "page": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page"
+          },
+          "size": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size"
+          },
+          "pages": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pages"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "total",
+          "page",
+          "size"
+        ],
+        "title": "DataPage[ActiveEventSchema]"
+      },
       "DataPage_CharacterSchema_": {
         "properties": {
           "data": {
@@ -3570,73 +3435,6 @@
           "size"
         ],
         "title": "DataPage[CharacterSchema]"
-      },
-      "DataPage_EventSchema_": {
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/EventSchema"
-            },
-            "type": "array",
-            "title": "Data"
-          },
-          "total": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Total"
-          },
-          "page": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Page"
-          },
-          "size": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size"
-          },
-          "pages": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Pages"
-          }
-        },
-        "type": "object",
-        "required": [
-          "data",
-          "total",
-          "page",
-          "size"
-        ],
-        "title": "DataPage[EventSchema]"
       },
       "DataPage_GEItemSchema_": {
         "properties": {
@@ -4381,55 +4179,6 @@
           "data"
         ],
         "title": "EquipmentResponseSchema"
-      },
-      "EventSchema": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name",
-            "description": "Name of the event."
-          },
-          "map": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MapSchema"
-              }
-            ],
-            "description": "Map of the event."
-          },
-          "previous_skin": {
-            "type": "string",
-            "title": "Previous Skin",
-            "description": "Previous map skin."
-          },
-          "duration": {
-            "type": "integer",
-            "title": "Duration",
-            "description": "Duration in minutes."
-          },
-          "expiration": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Expiration",
-            "description": "Expiration datetime."
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At",
-            "description": "Start datetime."
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "map",
-          "previous_skin",
-          "duration",
-          "expiration",
-          "created_at"
-        ],
-        "title": "EventSchema"
       },
       "FightSchema": {
         "properties": {


### PR DESCRIPTION
This is a breaking change, but in order to keep compability with the server's versioning scheme minor versions will be breaking.

Release notes:
https://discord.com/channels/1162610864021590036/1184705919968362636/1269825411282501684

Changelogs:

Server:
* remaingSeconds and totalSeconds removed from the CooldownSchema
* inventory_slotX and inventory_slotX_quantity removed from CharacterSchema
* Minimum cooldowns are now 3 seconds for actions.
* An error that allowed cooldowns to be bypassed has been fixed.
* Events are back.
* Logs are now limited to the last 100 account actions.
* Gold filter added to Get All characters (/characters/) endpoint.

Balancing:
* Mushroom Soup : "Gives 5 12% fire damage at the start of fight.
* Cheese : "Gives 5 12% air damage at the start of fight.
* Fried Eggs : "Gives 5 12% water damage at the start of fight. Craft: 3 5 eggs
* Beef Stew : "Gives 5 12% earth damage at the start of fight.
* GE Price update: Jasper crystal, Magical cure and all items containing them.
* Ge Price update:  Monster resources lvl 25 and more.

Client:
* Gold leaderboard added.

Documentation:
* Recycling page added:  https://docs.artifactsmmo.com/concepts/recycling